### PR TITLE
update codes for kafka streaming usage

### DIFF
--- a/springboot-kafka-streaming-project/consumer/.gitignore
+++ b/springboot-kafka-streaming-project/consumer/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/springboot-kafka-streaming-project/consumer/pom.xml
+++ b/springboot-kafka-streaming-project/consumer/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.2.0-M3</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>com.emma.springboot.kafka</groupId>
+	<artifactId>consumer</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>consumer</name>
+	<description>kafka topic dataset consumer</description>
+	<properties>
+		<java.version>17</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+	<repositories>
+		<repository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>https://repo.spring.io/milestone</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>https://repo.spring.io/milestone</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
+
+</project>

--- a/springboot-kafka-streaming-project/consumer/src/main/java/com/emma/springboot/kafka/consumer/ConsumerApplication.java
+++ b/springboot-kafka-streaming-project/consumer/src/main/java/com/emma/springboot/kafka/consumer/ConsumerApplication.java
@@ -1,0 +1,13 @@
+package com.emma.springboot.kafka.consumer;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ConsumerApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(ConsumerApplication.class, args);
+	}
+
+}

--- a/springboot-kafka-streaming-project/consumer/src/main/resources/application.properties
+++ b/springboot-kafka-streaming-project/consumer/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+server.port=10901

--- a/springboot-kafka-streaming-project/consumer/src/test/java/com/emma/springboot/kafka/consumer/ConsumerApplicationTests.java
+++ b/springboot-kafka-streaming-project/consumer/src/test/java/com/emma/springboot/kafka/consumer/ConsumerApplicationTests.java
@@ -1,0 +1,13 @@
+package com.emma.springboot.kafka.consumer;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ConsumerApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/springboot-kafka-streaming-project/producer/.gitignore
+++ b/springboot-kafka-streaming-project/producer/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/springboot-kafka-streaming-project/producer/pom.xml
+++ b/springboot-kafka-streaming-project/producer/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.2.0-M3</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>com.emma.springboot.kafka</groupId>
+	<artifactId>producer</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>producer</name>
+	<description>kafka producer to generate data in constant speed to feed the kafka streaming</description>
+	<properties>
+		<java.version>17</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>32.1.2-jre</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+	<repositories>
+		<repository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>https://repo.spring.io/milestone</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>https://repo.spring.io/milestone</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
+
+</project>

--- a/springboot-kafka-streaming-project/producer/src/main/java/com/emma/springboot/kafka/producer/ProducerApplication.java
+++ b/springboot-kafka-streaming-project/producer/src/main/java/com/emma/springboot/kafka/producer/ProducerApplication.java
@@ -1,0 +1,13 @@
+package com.emma.springboot.kafka.producer;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ProducerApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(ProducerApplication.class, args);
+	}
+
+}

--- a/springboot-kafka-streaming-project/producer/src/main/java/com/emma/springboot/kafka/producer/config/KafkaProducerTopicConfig.java
+++ b/springboot-kafka-streaming-project/producer/src/main/java/com/emma/springboot/kafka/producer/config/KafkaProducerTopicConfig.java
@@ -1,0 +1,19 @@
+package com.emma.springboot.kafka.producer.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+@Configuration
+public class KafkaProducerTopicConfig {
+    @Value("${spring.kafka.topic.name}")
+    private String topicName;
+
+    @Bean
+    public NewTopic topic() {
+        return TopicBuilder.name(this.topicName)
+                .build();
+    }
+}

--- a/springboot-kafka-streaming-project/producer/src/main/java/com/emma/springboot/kafka/producer/controller/StreamItemController.java
+++ b/springboot-kafka-streaming-project/producer/src/main/java/com/emma/springboot/kafka/producer/controller/StreamItemController.java
@@ -1,0 +1,51 @@
+package com.emma.springboot.kafka.producer.controller;
+
+import com.emma.springboot.kafka.producer.dto.StreamItemVo;
+import com.emma.springboot.kafka.producer.event.StreamItemEvent;
+import com.emma.springboot.kafka.producer.service.KafkaProducer;
+import org.apache.logging.log4j.util.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Objects;
+
+@RestController
+@RequestMapping("/api/v1/producer")
+public class StreamItemController {
+    private static final Logger LOG = LoggerFactory.getLogger(StreamItemController.class);
+
+    private KafkaProducer producer;
+
+    public StreamItemController(KafkaProducer kafkaProducer) {
+        this.producer = kafkaProducer;
+    }
+
+    @PostMapping("/item")
+    public ResponseEntity<String> postItem(@RequestBody StreamItemVo streamItemVo) {
+        StreamItemEvent streamItemEvent = new StreamItemEvent();
+        if (Objects.isNull(streamItemVo) || Strings.isEmpty(streamItemVo.getKey())) {
+            return new ResponseEntity<>("Bad Request", HttpStatus.BAD_REQUEST);
+        }
+
+        streamItemEvent.setData(streamItemVo);
+        streamItemEvent.setStatus("PENDING");
+        streamItemEvent.setMessage("Send Stream Item Data");
+
+        producer.sendMessage(streamItemEvent);
+        return new ResponseEntity<>("Success", HttpStatusCode.valueOf(200));
+    }
+
+    @PostMapping("/items")
+    public ResponseEntity<String> postItems(@RequestBody List<StreamItemVo> streamItemVoList) {
+
+        return new ResponseEntity<>("Success", HttpStatus.OK);
+    }
+}

--- a/springboot-kafka-streaming-project/producer/src/main/java/com/emma/springboot/kafka/producer/dto/StreamItemVo.java
+++ b/springboot-kafka-streaming-project/producer/src/main/java/com/emma/springboot/kafka/producer/dto/StreamItemVo.java
@@ -1,0 +1,23 @@
+package com.emma.springboot.kafka.producer.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@AllArgsConstructor
+@Data
+@ToString
+public class StreamItemVo {
+    private String key;
+    private List<String> values;
+
+    public StreamItemVo() {
+        this.values = new ArrayList<>();
+    }
+}
+
+

--- a/springboot-kafka-streaming-project/producer/src/main/java/com/emma/springboot/kafka/producer/event/StreamItemEvent.java
+++ b/springboot-kafka-streaming-project/producer/src/main/java/com/emma/springboot/kafka/producer/event/StreamItemEvent.java
@@ -1,0 +1,17 @@
+package com.emma.springboot.kafka.producer.event;
+
+import com.emma.springboot.kafka.producer.dto.StreamItemVo;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class StreamItemEvent {
+    private StreamItemVo data;
+    private String message;
+    private String status;
+
+}

--- a/springboot-kafka-streaming-project/producer/src/main/java/com/emma/springboot/kafka/producer/service/KafkaProducer.java
+++ b/springboot-kafka-streaming-project/producer/src/main/java/com/emma/springboot/kafka/producer/service/KafkaProducer.java
@@ -1,0 +1,34 @@
+package com.emma.springboot.kafka.producer.service;
+
+import com.emma.springboot.kafka.producer.event.StreamItemEvent;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class KafkaProducer {
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaProducer.class);
+
+    private NewTopic topic;
+
+    private KafkaTemplate<String, StreamItemEvent> kafkaTemplate;
+
+    public KafkaProducer(NewTopic topic, KafkaTemplate<String, StreamItemEvent> kafkaTemplate) {
+        this.topic = topic;
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public void sendMessage(StreamItemEvent event) {
+        LOG.info("#sendMessage Order Event => {}", event.toString());
+        Message<StreamItemEvent> message = MessageBuilder
+                .withPayload(event)
+                .setHeader(KafkaHeaders.TOPIC, this.topic.name())
+                .build();
+        kafkaTemplate.send(message);
+    }
+}

--- a/springboot-kafka-streaming-project/producer/src/main/resources/application.properties
+++ b/springboot-kafka-streaming-project/producer/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+server.port=10902

--- a/springboot-kafka-streaming-project/producer/src/test/java/com/emma/springboot/kafka/producer/ProducerApplicationTests.java
+++ b/springboot-kafka-streaming-project/producer/src/test/java/com/emma/springboot/kafka/producer/ProducerApplicationTests.java
@@ -1,0 +1,9 @@
+package com.emma.springboot.kafka.producer;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ProducerApplicationTests {
+
+}

--- a/springboot-kafka-streaming-project/streaming/.gitignore
+++ b/springboot-kafka-streaming-project/streaming/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/springboot-kafka-streaming-project/streaming/pom.xml
+++ b/springboot-kafka-streaming-project/streaming/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.2.0-M3</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>com.emma.springboot.kafka</groupId>
+	<artifactId>streaming</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>streaming</name>
+	<description>kafka streaming classic secnarios</description>
+	<properties>
+		<java.version>17</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>kafka-streams</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+	<repositories>
+		<repository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>https://repo.spring.io/milestone</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>https://repo.spring.io/milestone</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
+
+</project>

--- a/springboot-kafka-streaming-project/streaming/src/main/java/com/emma/springboot/kafka/streaming/StreamingApplication.java
+++ b/springboot-kafka-streaming-project/streaming/src/main/java/com/emma/springboot/kafka/streaming/StreamingApplication.java
@@ -1,0 +1,13 @@
+package com.emma.springboot.kafka.streaming;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class StreamingApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(StreamingApplication.class, args);
+	}
+
+}

--- a/springboot-kafka-streaming-project/streaming/src/main/java/com/emma/springboot/kafka/streaming/config/KafkaStreamConfig.java
+++ b/springboot-kafka-streaming-project/streaming/src/main/java/com/emma/springboot/kafka/streaming/config/KafkaStreamConfig.java
@@ -1,0 +1,67 @@
+package com.emma.springboot.kafka.streaming.config;
+
+
+import com.emma.springboot.kafka.streaming.entity.StreamItem;
+import com.emma.springboot.kafka.streaming.mapper.StreamItemMapper;
+import com.emma.springboot.kafka.streaming.reducer.StreamItemReducer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.EnableKafkaStreams;
+import org.springframework.kafka.annotation.KafkaStreamsDefaultConfiguration;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerde;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableKafka
+@EnableKafkaStreams
+public class KafkaStreamConfig {
+    @Autowired
+    private KafkaProperties kafkaProperties;
+
+    @Value("${kafka.stream.topic}")
+    private String kafkaStreamTopic;
+
+    @Bean(name = KafkaStreamsDefaultConfiguration.DEFAULT_STREAMS_CONFIG_BEAN_NAME)
+    public StreamsConfig kStreamsConfigs() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(StreamsConfig.APPLICATION_ID_CONFIG, "kafka-stream");
+        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getBootstrapServers());
+        props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, new JsonSerde<>(StreamItem.class));
+        props.put(JsonDeserializer.KEY_DEFAULT_TYPE, String.class);
+        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, StreamItem.class);
+        return new StreamsConfig(props);
+    }
+
+    @Bean
+    public KStream<String, StreamItem> kStreamJson(StreamsBuilder builder) {
+        KStream<String, StreamItem> stream = builder.stream( kafkaStreamTopic,
+                Consumed.with(Serdes.String(), new JsonSerde<>(StreamItem.class)));
+        KTable<String, StreamItem> combinedDocuments = stream
+                .map(new StreamItemMapper())
+                .groupByKey()
+                .reduce(new StreamItemReducer(), Materialized.<String, StreamItem, KeyValueStore<Bytes, byte[]>>
+                        as("streams-json-store"));
+        combinedDocuments.toStream().to("stream-json-input", Produced.with(Serdes.String(),
+                new JsonSerde<>(StreamItem.class)));
+
+        return stream;
+    }
+}

--- a/springboot-kafka-streaming-project/streaming/src/main/java/com/emma/springboot/kafka/streaming/entity/StreamItem.java
+++ b/springboot-kafka-streaming-project/streaming/src/main/java/com/emma/springboot/kafka/streaming/entity/StreamItem.java
@@ -1,0 +1,18 @@
+package com.emma.springboot.kafka.streaming.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class StreamItem {
+    private String key;
+    private List<String> values;
+
+    public StreamItem() {
+     this.values = new ArrayList<>();
+    }
+}

--- a/springboot-kafka-streaming-project/streaming/src/main/java/com/emma/springboot/kafka/streaming/mapper/StreamItemMapper.java
+++ b/springboot-kafka-streaming-project/streaming/src/main/java/com/emma/springboot/kafka/streaming/mapper/StreamItemMapper.java
@@ -1,0 +1,13 @@
+package com.emma.springboot.kafka.streaming.mapper;
+
+import com.emma.springboot.kafka.streaming.entity.StreamItem;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.kstream.KeyValueMapper;
+import org.springframework.kafka.config.KafkaStreamsConfiguration;
+
+public class StreamItemMapper implements KeyValueMapper<String, StreamItem, KeyValue<String, StreamItem>> {
+    @Override
+    public KeyValue<String, StreamItem> apply(String s, StreamItem streamItem) {
+        return new KeyValue<String, StreamItem>(streamItem.getKey(), streamItem);
+    }
+}

--- a/springboot-kafka-streaming-project/streaming/src/main/java/com/emma/springboot/kafka/streaming/reducer/StreamItemReducer.java
+++ b/springboot-kafka-streaming-project/streaming/src/main/java/com/emma/springboot/kafka/streaming/reducer/StreamItemReducer.java
@@ -1,0 +1,30 @@
+package com.emma.springboot.kafka.streaming.reducer;
+
+import com.emma.springboot.kafka.streaming.entity.StreamItem;
+import org.apache.kafka.streams.kstream.Reducer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.CollectionUtils;
+
+import java.util.Objects;
+
+public class StreamItemReducer implements Reducer<StreamItem> {
+    private static final Logger LOG = LoggerFactory.getLogger(StreamItemReducer.class);
+
+    @Override
+    public StreamItem apply(StreamItem item1, StreamItem item2) {
+        LOG.info("#apply recv item1 non-null status {}, item2 non-null status {}",
+                Objects.nonNull(item1), Objects.nonNull(item2));
+        if (Objects.isNull(item1) || CollectionUtils.isEmpty(item1.getValues())) {
+            LOG.info("#apply recv item1 is empty, return item2");
+            return item2;
+        } else if (Objects.isNull(item2) || CollectionUtils.isEmpty(item2.getValues())) {
+            LOG.info("#apply recv item1 is empty, return item2");
+            return item1;
+        } else {
+            LOG.info("#apply recv item1 and item2 non-empty, merge them and return!");
+            item1.getValues().addAll(item2.getValues());
+            return item1;
+        }
+    }
+}

--- a/springboot-kafka-streaming-project/streaming/src/main/resources/application.properties
+++ b/springboot-kafka-streaming-project/streaming/src/main/resources/application.properties
@@ -1,0 +1,9 @@
+server.port=10903
+
+# to kafka stream module most of the customized configuration options are defined
+# in the context of java codes
+
+spring.kafka.bootstrap-servers=localhost:9092
+kafka.stream.topic=kafka-stream-input-topic
+spring.main.allow-bean-definition-overriding=true
+spring.kafka.streams.application-id=kafka-stream-app-id

--- a/springboot-kafka-streaming-project/streaming/src/test/java/com/emma/springboot/kafka/streaming/StreamingApplicationTests.java
+++ b/springboot-kafka-streaming-project/streaming/src/test/java/com/emma/springboot/kafka/streaming/StreamingApplicationTests.java
@@ -1,0 +1,13 @@
+package com.emma.springboot.kafka.streaming;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class StreamingApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}


### PR DESCRIPTION
In this commit , add kafka streaming usage in spring boot.

in the project, we create a producer in the `producer` module and every time user send post request to send data of `StreamItemVo` in single or in list . The request body will be verified and converted into the Event(s) and send to the specificed topic that with the name of `kafka-stream-input-topic`. 

Because we use kafka-streaming to listen to the speicific topic `kafka-stream-input-topic` , so as soon as the kafka broker receives the dataset arrives, it will be 'consumed' actually 'subscribed' by the kafka stream that implemented in the module `streaming`.


When kafka streaming receives the data, it will do the merge operation upon each stream's item as long as their key value match. And the merge operation is implemented in the `StreamItemMapper` and `StreamItemReducer` it executes the same thing just like the Hadoop frame work does, but kafka-streaming is a more light-weight than the Hadoop/Spark.